### PR TITLE
fix(token-injector-ci): Github action file ref

### DIFF
--- a/.github/workflows/release-token-injector-images.yml
+++ b/.github/workflows/release-token-injector-images.yml
@@ -24,7 +24,7 @@ jobs:
           filters: |
             source_code:
               - cmd/token-injector/**
-              - .github/release-token-injector-images.yml
+              - .github/workflows/release-token-injector-images.yml
       - name: Detect if token-injector-webhook source code changed
         uses: dorny/paths-filter@v3
         id: changes_token_injector_webhook
@@ -32,7 +32,7 @@ jobs:
           filters: |
             source_code:
               - cmd/token-injector-webhook/**
-              - .github/release-token-injector-images.yml
+              - .github/workflows/release-token-injector-images.yml
     outputs:
       check_token_injector: ${{ steps.changes_token_injector.outputs.source_code }}
       check_token_injector_webhook: ${{ steps.changes_token_injector_webhook.outputs.source_code }}


### PR DESCRIPTION
- I forgot the workflows subdirectory in the source_code check.  This disallowed the image to be built.
- Relates: https://linear.app/prefect/issue/PLA-1167/relevant-iam-roles-sas-for-fargate-cluster-access