### PR TITLE
fix(token-injector-ci): Docker build step use working dir

### DIFF
--- a/.github/workflows/release-token-injector-images.yml
+++ b/.github/workflows/release-token-injector-images.yml
@@ -86,7 +86,7 @@ jobs:
         if: needs.check_if_code_changed.outputs.check_token_injector == 'true'
         working-directory: ./cmd/token-injector
         run: |
-          docker build "${{ github.workspace }}" --no-cache -t local-mex-aws-token-injector:${{ env.SHORT_SHA }}
+          docker build --no-cache -t local-mex-aws-token-injector:${{ env.SHORT_SHA }} .
       # otherwise, fetch the :latest image from dev
       - name: Fetch latest token-injector image from dev-mex-aws-token-injector
         if: needs.check_if_code_changed.outputs.check_token_injector == 'false'
@@ -134,7 +134,7 @@ jobs:
         if: needs.check_if_code_changed.outputs.check_token_injector_webhook == 'true'
         working-directory: ./cmd/token-injector-webhook
         run: |
-          docker build "${{ github.workspace }}" --no-cache -t local-mex-aws-token-injector-webhook:${{ env.SHORT_SHA }}
+          docker build --no-cache -t local-mex-aws-token-injector-webhook:${{ env.SHORT_SHA }} .
       - name: Fetch latest token-injector-webhook image from dev-mex-aws-token-injector-webhook
         if: needs.check_if_code_changed.outputs.check_token_injector_webhook == 'false'
         run: |


### PR DESCRIPTION
- Using github.workspace resets the working dir to the top level directory.  This change should resolve that issue and allow the build to commence. 
- Relates: https://linear.app/prefect/issue/PLA-1167/relevant-iam-roles-sas-for-fargate-cluster-access