### PR TITLE
Fix(mex ci): Workload identity provider secret ref for trivvy scans

### DIFF
--- a/.github/workflows/release-token-injector-images.yml
+++ b/.github/workflows/release-token-injector-images.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ vars.GHA_WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: ${{ secrets.GHA_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: mex-aws-tkn-inj-pr-mrg-wf-main@prefect-org-github-actions.iam.gserviceaccount.com
       - name: Configure Google Cloud credential helper
         run: gcloud auth configure-docker --quiet us-docker.pkg.dev
@@ -231,7 +231,7 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ vars.GHA_WORKLOAD_IDENTITY_PROVIDER }}
+          workload_identity_provider: ${{ secrets.GHA_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: mex-aws-tkn-inj-pr-mrg-wf-main@prefect-org-github-actions.iam.gserviceaccount.com
       - name: Configure Google Cloud credential helper
         run: gcloud auth configure-docker --quiet us-docker.pkg.dev


### PR DESCRIPTION
- This is a secret not a var as this repo was initially created as a fork so the org var was not stashed.
- Relates: https://linear.app/prefect/issue/PLA-1167/relevant-iam-roles-sas-for-fargate-cluster-access