### PR TITLE
feat(ci): Take ownership of modules and add precommit script

### DIFF
--- a/.github/workflows/build-push-token-injector-images.yml
+++ b/.github/workflows/build-push-token-injector-images.yml
@@ -161,6 +161,7 @@ jobs:
     needs:
       - get_image_version
       - build_and_push_token_injector_images
+      - check_if_code_changed
     runs-on: ubuntu-latest
     env:
       SHORT_SHA: ${{ needs.get_image_version.outputs.short_sha }}
@@ -214,6 +215,7 @@ jobs:
     needs:
       - get_image_version
       - build_and_push_token_injector_webhook_images
+      - check_if_code_changed
     runs-on: ubuntu-latest
     env:
       SHORT_SHA: ${{ needs.get_image_version.outputs.short_sha }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+---
+fail_fast: false
+
+repos:
+  - repo: local
+    hooks:
+      - id: golong-pre-commit
+        name: golong-pre-commit
+        entry: scripts/golong-pre-commit.sh
+        language: script
+        types: [file]
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.1
+    hooks:
+      - id: actionlint

--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ All required steps for configuring Kubernetes Mutating Admission webhook are des
 When we started to develop an Kubernetes Admission Webhook we notice that there was a requirement that enforced by the apiserver for the admission webhook server and this is TLS connection so apiserver and admission webhook server must connect via TLS with each other. See: [Contacting the webhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#contacting-the-webhook). To ensure that we need a CA (Certificate Authority) and a client certificate which is signed by this CA.
 
 For creation and signing certificate was created separate tool, which could be run as a Kubernetes Job:
-- [Admission webhook certificator](https://github.com/ealebed/admission-webhook-certificator)
+- [Admission webhook certificator](https://github.com/PrefectHQ/admission-webhook-certificator)
 
 I've inspired the initial mutating admission webhook code from [doitintl/gtoken](https://github.com/doitintl/gtoken/tree/master) repository. Big thanks to Alexei Ledenev!

--- a/cmd/token-injector-webhook/Dockerfile
+++ b/cmd/token-injector-webhook/Dockerfile
@@ -44,6 +44,6 @@ FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # this is the last commabd since it's never cached
-COPY --from=build /go/src/token-injector-webhook/.bin/github.com/ealebed/token-injector/token-injector-webhook /token-injector-webhook
+COPY --from=build /go/src/token-injector-webhook/.bin/github.com/PrefectHQ/mex-aws-token-injector/token-injector-webhook /token-injector-webhook
 
 ENTRYPOINT ["/token-injector-webhook"]

--- a/cmd/token-injector-webhook/go.mod
+++ b/cmd/token-injector-webhook/go.mod
@@ -1,4 +1,4 @@
-module github.com/ealebed/token-injector/token-injector-webhook
+module github.com/PrefectHQ/mex-aws-token-injector/token-injector-webhook
 
 go 1.24.0
 

--- a/cmd/token-injector-webhook/main_test.go
+++ b/cmd/token-injector-webhook/main_test.go
@@ -180,7 +180,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 		{
 			name: "mutate pod",
 			fields: fields{
-				image:      "ealebed/token-injector/token-injector:test",
+				image:      "PrefectHQ/mex-aws-token-injector/token-injector:test",
 				pullPolicy: "Always",
 				volumeName: "test-volume-name",
 				volumePath: "/test-volume-path",
@@ -207,7 +207,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:    "generate-gcp-id-token",
-							Image:   "ealebed/token-injector/token-injector:test",
+							Image:   "PrefectHQ/mex-aws-token-injector/token-injector:test",
 							Command: []string{"/token-injector", "--file=/test-volume-path/test-token", "--refresh=false"},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
@@ -241,7 +241,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 						},
 						{
 							Name:    "update-gcp-id-token",
-							Image:   "ealebed/token-injector/token-injector:test",
+							Image:   "PrefectHQ/mex-aws-token-injector/token-injector:test",
 							Command: []string{"/token-injector", "--file=/test-volume-path/test-token", "--refresh=true"},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{

--- a/cmd/token-injector/.golangci.yaml
+++ b/cmd/token-injector/.golangci.yaml
@@ -53,7 +53,7 @@ linters-settings:
           - "!$test"
         allow:
           - $gostd
-          - github.com/ealebed/token-injector/token-injector/internal/gcp
+          - github.com/PrefectHQ/mex-aws-token-injector/token-injector/internal/gcp
           - cloud.google.com/go/compute/metadata
           - github.com/dgrijalva/jwt-go
           - github.com/pkg/errors

--- a/cmd/token-injector/Dockerfile
+++ b/cmd/token-injector/Dockerfile
@@ -45,6 +45,6 @@ FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # this is the last commabd since it's never cached
-COPY --from=build /go/src/token-injector/.bin/github.com/ealebed/token-injector/token-injector /token-injector
+COPY --from=build /go/src/token-injector/.bin/github.com/PrefectHQ/mex-aws-token-injector/token-injector /token-injector
 
 ENTRYPOINT ["/token-injector"]

--- a/cmd/token-injector/go.mod
+++ b/cmd/token-injector/go.mod
@@ -1,4 +1,4 @@
-module github.com/ealebed/token-injector/token-injector
+module github.com/PrefectHQ/mex-aws-token-injector/token-injector
 
 go 1.24.0
 

--- a/cmd/token-injector/main.go
+++ b/cmd/token-injector/main.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/ealebed/token-injector/token-injector/internal/gcp"
+	"github.com/PrefectHQ/mex-aws-token-injector/token-injector/internal/gcp"
 
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/token-injector/main_test.go
+++ b/cmd/token-injector/main_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ealebed/token-injector/token-injector/internal/gcp"
+	"github.com/PrefectHQ/mex-aws-token-injector/token-injector/internal/gcp"
 )
 
 //nolint:funlen

--- a/docs/admission_webhook_configuration.md
+++ b/docs/admission_webhook_configuration.md
@@ -1,7 +1,7 @@
 # Webhook Configuration Description
 
 ## General information and prerequisites
-1. Container images for `token-injector-webhook`, `token-injector` tool and `certificator` tool (see separate [repository](https://github.com/ealebed/admission-webhook-certificator)) should be built and uploaded to the Container Registry accessible from GKE cluster.
+1. Container images for `token-injector-webhook`, `token-injector` tool and `certificator` tool (see separate [repository](https://github.com/PrefectHQ/admission-webhook-certificator)) should be built and uploaded to the Container Registry accessible from GKE cluster.
 
 2. Google Service account which will be used for accessing AWS resources must be created with the following roles:
   - `roles/iam.workloadIdentityUser` - to impersonate service accounts from GKE Workloads
@@ -21,15 +21,15 @@
 
 6. GKE namespaces for Application workload and Admission webhook.
 
-7. GKE Service Account for creation secret (with signed certificate and private key) and running Admission webhook in respective GKE namespace (see example in separate [repository](https://github.com/ealebed/admission-webhook-certificator/blob/master/manifests/service-account.yaml)).
+7. GKE Service Account for creation secret (with signed certificate and private key) and running Admission webhook in respective GKE namespace (see example in separate [repository](https://github.com/PrefectHQ/admission-webhook-certificator/blob/main/manifests/service-account.yaml)).
 
 8. GKE Cluster Role and Cluster Role Binding for Admission webhook Service Account.
 
-9. GKE Cluster Role and Cluster Role Binding for `certificator` tool Service Account (see exapmles in separate [repository](https://github.com/ealebed/admission-webhook-certificator/tree/master/manifests))
+9. GKE Cluster Role and Cluster Role Binding for `certificator` tool Service Account (see exapmles in separate [repository](https://github.com/PrefectHQ/admission-webhook-certificator/tree/main/manifests))
 
 10. Annotated GKE Service Account for running Application workload in respective GKE namespace.
 
-11. GKE Job for `certificator` tool (used for creation secret with signed certificate and private key) (see example in separate [repository](https://github.com/ealebed/admission-webhook-certificator/blob/master/manifests/job.yaml)).
+11. GKE Job for `certificator` tool (used for creation secret with signed certificate and private key) (see example in separate [repository](https://github.com/PrefectHQ/admission-webhook-certificator/blob/main/manifests/job.yaml)).
 
 12. GKE Deployment for running Admission webhook in respective GKE namespace.
 
@@ -39,6 +39,4 @@
 
 ## Configuration steps
 All required steps for configuring Kubernetes Mutating Admission webhook are described in separate documents:
-- [Manual configuration](./docs/manual_configuration.md)
-- [Terraform configuration](./docs/terraform_configuration.md)
-- [HELM chart configuration](./docs/helm_configuration.md)
+- [Helm chart configuration](./docs/helm_configuration.md)

--- a/docs/helm_configuration.md
+++ b/docs/helm_configuration.md
@@ -1,7 +1,7 @@
 # Webhook Configuration with HELM chart
 
 ## Prerequisites
-- Container images for `token-injector-webhook`, `token-injector` tool and `certificator` tool (see separate [repository](https://github.com/ealebed/admission-webhook-certificator)) should be built and uploaded to the Container Registry accessible from GKE cluster.
+- Container images for `token-injector-webhook`, `token-injector` tool and `certificator` tool (see separate [repository](https://github.com/PrefectHQ/admission-webhook-certificator)) should be built and uploaded to the Container Registry accessible from GKE cluster.
 - Export AWS credentials into environment variables
 ```bash
 export AWS_ACCESS_KEY_ID="aws-access-key-id"

--- a/scripts/golong-pre-commit.sh
+++ b/scripts/golong-pre-commit.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# cd to the token-injector-webhook directory
+cd cmd/token-injector-webhook
+# Run gofmt on all files in the cmd/token-injector-webhook directory
+go fmt ./
+# Run go vet on all files in the cmd/token-injector-webhook directory
+go vet ./
+# Run go imports on all files in the cmd/token-injector-webhook directory
+goimports -w ./
+# Run golangci-lint on all files in the cmd/token-injector-webhook directory
+golangci-lint run ./
+# Run go unit tests on all files in the cmd/token-injector-webhook directory
+go test ./...
+# Run go mod tidy on all files in the cmd/token-injector-webhook directory
+go mod tidy
+# cd back to the root directory
+cd ../token-injector
+# Run gofmt on all files in the cmd/token-injector directory
+go fmt ./
+# Run go vet on all files in the cmd/token-injector directory
+go vet ./
+# Run go imports on all files in the cmd/token-injector directory
+goimports -w ./
+# Run golangci-lint on all files in the cmd/token-injector directory
+golangci-lint run ./
+# Run go unit tests on all files in the cmd/token-injector directory
+go test ./...
+# Run go mod tidy on all files in the cmd/token-injector directory
+go mod tidy


### PR DESCRIPTION
- Fixes a little miss on the needs part of the CI workflow
- Creates pre-commit script for golang ci as sub precommit ci's don't exist natively yet so needed to write a bash script that does essentially the same thing
- Taking ownership of the go modules from the original creator of these packages; ealebed (Again shoutout to this person for writing all of this from the start!)